### PR TITLE
FIX: template error when page has no id

### DIFF
--- a/WeMove/wrapper.html
+++ b/WeMove/wrapper.html
@@ -24,7 +24,10 @@
     <meta name="twitter:card" content="summary">
     {% endblock %}
 
+    {% if page.id %}
     {% store as campaign_type %}{% report "custom_field_from_page_or_campaign" with 1 as refresh page.id as page_id "campaign_type" as field_name %}{% endstore %}
+    {% endif %}
+
     {% if campaign_type == "youmove" %}
     <link href="https://youmoveeurope.eu/favicon.png" rel="icon" />
     {% else %}


### PR DESCRIPTION
This fixes the template error when members visit /login/ or /logout/ or indeed any page that does not have page.id.

Background:

Sometimes authentication is forced when a member follows certain links, such as their profile page or even the logout page in ActionKit. Scenarios where this can happen include when visiting a [Recurring Donation Upscale page](https://action.wemove.eu/admin/core/recurringdonationupdatepage/4030/change/), (currently under development). Those pages do not have a page.id value which causes an error in the rendering of wrapper.html.

![image](https://github.com/WeMoveEU/actionkit-templatesets/assets/1378331/3ded9ba0-29ac-4d93-a862-717a72dccf8e)

This pull request fixes this issue, as advised by ActionKit support.