### PR TITLE
Update dash_campaign_admin.html

### DIFF
--- a/WeMove/dash_campaign_admin.html
+++ b/WeMove/dash_campaign_admin.html
@@ -1018,7 +1018,7 @@
 		var page_type = action_type;
 		if (action_type == 'tweet') {
 			page_type = 'call';
-			fields.call_page_mode = 'twitter';
+			fields.call_page_mode = 'tweet';
 		} else if (action_type == 'facebook') {
 			page_type = 'call';
 			fields.call_page_mode = 'facebook';


### PR DESCRIPTION
Custom page field options are:

```
call=Call to Targets
tweet=Tweet at Targets
facebook=Post on Target's Facebook
```

but dashboard is setting 'twitter' as value, resulting in wrong call page mode value in created page.