### PR TITLE
Support for End of Year fundraising asks - "increase your recurring donation"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
+
+tags

--- a/WeMove/login.html
+++ b/WeMove/login.html
@@ -1,57 +1,77 @@
 {% extends "./wrapper.html" %}
 
+
 {% block content %}
 
-<div class="ak-grid-row">
-    <div class="ak-grid-col ak-grid-col-4-of-12 ak-grid-centered">
-        <h2>Log In</h2>
+{% comment %}
 
-        <div class="area">
-            {% if error_message %}
-                <p class="errornote">{{ error_message }}</p>
-            {% endif %}
-            {% if invalid %}
-                <p class="errornote">Incorrect email or password.  Try again, or <a href="{% url 'user_password_forgot' %}?next={{ next }}&email={{ email }}">we can email you a link to reset your password</a>.</p>
-            {% endif %}
+TODO:
 
-            <div id="content-main">
-                {% if no_password %}
-                    <p>It looks like you've never logged in before. <a href="{% url 'user_password_forgot' %}?email={{ email }}">Click here to set up a password.</a>.</p>
-                {% endif %}
-                {% if wrong_account %}
-                    <p>It looks like you may need another email address to view that page, or the page may no longer be accessible.</p>
-                {% endif %}
-                <form action="{{ app_path }}" method="post" id="login-form" name="login-form">
-                    <input type="hidden" name="this_is_the_login_form" value="1">
-                    <input type="hidden" name="next" value="{{ next }}">
-                    <input type="hidden" name="required" value="password">
-                    
-                    <div class="ak-styled-fields ak-labels-above ak-errs-below ak-clearfix">
-                    
-                        <div>
-                            <label for="id_email">Email</label>
-                            <input type="text" name="email" value="{{ email }}" id="id_email" class="ak-full-width">
-                        </div>
-                        <div>
-                            <label for="id_password">Password</label>
-                            <input type="password" name="password" id="id_password" class="ak-full-width">
-                        </div>
-                        
-                        <button type="submit" class="ak-submit-button">Log In</button>
+ - update styles to login from peititon
 
-                    </div>
+{% endcomment %}
 
-                    <div>
-                        <a href="{% url 'user_password_forgot' %}?next={{ next }}&amp;email={{ email }}">Forgot your password?</a>
-                    </div>
-                    <div>
-                        <a href="{% url 'user_password_forgot' %}?next={{ next }}&amp;first=1&amp;email={{ email }}">Never logged in before?</a>
-                    </div>
+<div class="nav-md:grid grid-cols-petition">
+  <article>
+    <div class="relative">
 
-                </form>
-            </div>
-        </div>
+      <h1 class="nav-md:mb-8 nav-md:pr-40">
+          {% filter ak_text:"login_title" %}Oops, we need to verify who you are before showing you that page!{% endfilter %}
+      </h1>
+
     </div>
+
+    {% comment %}{% include "./component-featured-image.html" with featured_image="https://wemove.eu/_next/image?url=%2Fuploads%2Fdeep_sea_c5eae5733c.jpg&w=2048&q=75"  %} {% endcomment %}
+
+    <div class="nav-md:mr-4">
+      <div class="text-wm-purple p-6 bg-wm-lightblue-box mt-4 mb-8 font-normal text-base font-libre-franklin">
+        {% filter ak_text:"magic_link_explanation" %}We'll send a magic link to your email to log you in.{% endfilter %}
+      </div>
+
+    <form
+      class="ak-form ak-styled-fields ak-labels-overlaid ak-errs-below is-floating
+      bg-wm-bg-form p-4 h-fit mx-auto max-w-[500px]"
+      name="login-form"
+      method="post"
+      action="/act/"
+      accept-charset="utf-8"
+      data-wm-form="sursignupvey"
+      data-wm-floating-labels-form>
+
+      <input type="hidden" name="page" value="magic-link-confirmation" />
+      <input type="hidden" name="action_redirect_to" value="{{ request.GET.next }}" />
+
+      {% if request.GET.akid %}
+
+      <input type="hidden" name="akid" value="{{ request.GET.akid }}" />
+
+      {% else %}
+
+
+      <div class="form-wrapper-container" style="min-height: auto;">
+        <div data-wm-form-field="email" id="ak-fieldbox-email" 
+             class="form-field required field-ak-type--user field-type--text ak-err-below">
+            <label for="id_email" class="ak-is-overlaid ak-error" style="cursor: text; pointer-events: none;">
+                Your email:
+            </label>
+            <input type="text" name="email" id="id_email" class="ak-userfield-input ak-has-overlay ak-error">
+            <ul class="ak-err"><li>Your email is required.</li></ul>
+        </div>
+      </div>
+
+      {% endif %}
+
+      <div class="mb-2">
+        <button type="submit" class="ak-submit-button">
+            {% filter ak_text:"button_send_email" %}Send Email{% endfilter %}
+        </button>
+      </div>
+
+    </div>
+  </article>
+
+</form>
+
 </div>
 
 {% endblock %}
@@ -59,10 +79,13 @@
 {% block below_form %}
 
 <script>
+    // not sure we need or want context here
     actionkit.forms.contextRoot = '/context/';
-    actionkit.forms.initValidation('login-form');
+    actionkit.forms.initPage();
+    actionkit.forms.initForm('login-form');
     
-    document.getElementById('id_{% if email %}password{% else %}email{% endif %}').focus()
+    const email = document.getElementById('id_email');
+    if (email) { email.focus(); }
 </script>
 
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/main-a6ba8b10.css" />
+<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/main.css" />
 
 {% endblock %}
 
@@ -119,5 +119,5 @@ TODO:
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.not-a2.eu/assets/main-e45c39d4.js"></script>
+<script type="module" src="https://donate-ui.not-a2.eu/assets/main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -72,7 +72,7 @@ For now this page is entirely dependent on the query string ! If we ever need to
 
             <div style="display: none;">
                 <form id="actionkit-form" name="act" action="/act/" method="POST">
-                    <input type="hidden" name="page" value="upscaled-donation-tracking" />
+                    <input type="hidden" name="page" value="tracking-upscaled-donations" />
                     <input type="hidden" name="akid" value="{{ logged_in_user.token }}" />
                     <input type="hidden" name="action_upscale_page" value="{{ page.name }}" />
                     <input type="hidden" name="action_upscale_amount" value="" />
@@ -100,9 +100,9 @@ For now this page is entirely dependent on the query string ! If we ever need to
             </div>
 
             <script>
-                const confirm = document.getElementById('confirm-amount-change')
-                confirm.addEventListener('wemove:complete', (evt) => {
+                document.addEventListener('payment-update', (evt) => {
                     const form = document.getElementById('actionkit-form');
+                    console.debug(evt);
                     // TODO: evt.amount is just a made-up placeholder, update to whatever the 
                     //       widget actually sends.
                     form.action_upscale_amount.value = evt.amount;

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -1,6 +1,20 @@
 {% extends "./wrapper.html" %}
 {% load humanize %}
 
+{% comment %} 
+
+Update your recurring donation
+=================================
+
+There are a couple ways to update a recurring donation:
+
+ - Change the amount (upscaling). DONE.
+ - Change the payment method.     TODO.
+
+For now this page is entirely dependent on the query string ! If we ever need to pull in data about the current recurring donation(s), we'll need to use a report. I couldn't figure out why the built-in ActionKit template doesn't find any recurring donations. Maybe it ignored "Import Stub" payment accounts? I don't know.
+
+{% endcomment %}
+
 {% block css_additions %}
 <link rel="stylesheet" href="https://donate-ui.not-a2.eu/donate-main.css" />
 
@@ -17,13 +31,6 @@
     </div>
 </div>
 
-{% comment %}
-TODO:
-
-- active has nothing in it even for users that have active recurring donations
-- inactive has some
-
-{% endcomment %}
 <div class="ak-grid-row ak-grid-row-inverted">
     {% if page.custom_fields.featured_image %}
         <div class="ak-grid-col ak-grid-col-3-of-12">
@@ -43,12 +50,38 @@ TODO:
 
         <p>{% include_tmpl form.update_card_text %}</p>
 
+        {% comment %} 
+          
+        This report returns these fields in this order:
+
+            amount, currency, status, account, start_date
+
+        {% endcomment %}
+        {% store as profiles %}
+        {% report "recurring_profile" with args.profile as recurring_id logged_in_user.id as user_id %}
+        {% endstore %}
+
+        {% remember profiles.0 as profile %}
+
         {% if action %}
             <h3>Update saved!</h3>
             <div>
                 {% include_tmpl form.thank_you_text %}
             </div>
         {% else %}
+
+            <div style="display: none;">
+                <form id="actionkit-form" name="act" action="/act/" method="POST">
+                    <input type="hidden" name="page" value="upscaled-donation-tracking" />
+                    <input type="hidden" name="akid" value="{{ logged_in_user.token }}" />
+                    <input type="hidden" name="action_upscale_page" value="{{ page.name }}" />
+                    <input type="hidden" name="action_upscale_amount" value="" />
+                    <input type="hidden" name="action_upscale_currency" value="{{ profile.currency }}" />
+                    <input type="hidden" name="action_upscale_previous_amount" value="{{ profile.amount }}" />
+                </form>
+            </div>
+
+            <div id="confirm-amount-change">
 
             {% for amount in args.amounts|split:',' %}
                 <div style="padding: 1em;">
@@ -64,57 +97,23 @@ TODO:
                 </div>
             {% endfor %}
 
+            </div>
+
+            <script>
+                const confirm = document.getElementById('confirm-amount-change')
+                confirm.addEventListener('wemove:complete', (evt) => {
+                    const form = document.getElementById('actionkit-form');
+                    // TODO: evt.amount is just a made-up placeholder, update to whatever the 
+                    //       widget actually sends.
+                    form.action_upscale_amount.value = evt.amount;
+                    form.submit();
+                })
+            </script>
+
 
         {% endif %}
 
 
-        <div id="active-donations">
-        </div>
-
-
-        {% comment %}
-
-        OK, the code below  gets the current user's active recurring donations, but it has
-        a few problems before we can do anything interesting like "Hey Bob! You currently
-        have a monthly/weekly donation for X that started on Y and you've given Z total!"
-
-        - a field to tell if the donation is weekly / monthly needs to be added in the report
-        - translations need to be added
-
-        So totally doable if we need it.
-
-        <script>
-        const donations = [{% report "recurring_donations_for_user" with logged_in_user.id as user_id "active" as status args.t as cache_key %}];
-        const subscriptions = donations[0];
-        let info = '<ul>';
-        const fields = subscriptions[0];
-        for (var i=1; i<subscriptions.length; i++) {
-            const d = {};
-            for (var x=0;x<fields.length;x++) {
-                d[fields[x]] = subscriptions[i][x]
-            }
-            info += `<b>${d.recurring_id}</b>`;
-        }
-        info += '</ul>';
-        document.getElementById('active-donations').innerHTML = info;
-        </script> {% endcomment %}
-
-
-
-        {% comment %}
-            This is an example of how to show inactive profiles.
-            {% if inactive %}
-
-
-                <label class="ak-label-above">Your old, no longer active recurring donations</label>
-                <ul>
-                    {% for profile in inactive %}
-                    <li>{{ profile.id }} - {{ profile.status }} on {{ profile.updated_at }}. Started on {{ profile.start }}, {% with profile.payment_count as count %} {{ count }} {{ profile.get_period_display|lower }} payment{{ count|pluralize }}{% endwith %} were made for a total of {{ profile.payment_total_amt }}.</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-
-        {% endcomment %}
 
     </div>
 

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -53,7 +53,6 @@ There are a couple ways to update a recurring donation:
 
         {% with profile_details|load_json as profile %}
 
-        <div class="recurring-update-about-text">{% include_tmpl form.update_card_text %}</div>
 
         {% if action %}
 
@@ -64,46 +63,7 @@ There are a couple ways to update a recurring donation:
 
         {% else %}
 
-            <div style="display: none;">
-                <form id="actionkit-form" name="act" action="/act/" method="POST">
-                    <input type="hidden" name="page" value="tracking-upscaled-donations-{{ page.lang.iso_code }}" />
-                    <input type="hidden" name="akid" value="{{ logged_in_user.token }}" />
-                    <input type="hidden" name="action_upscale_page" value="{{ page.name }}" />
-                    <input type="hidden" name="action_profile" value="{{ profile.id }}" />
-                    <input type="hidden" name="action_recurring_id" value="{{ profile.recurring_id }}" />
-                    <input type="hidden" name="action_upscale_amount" value="" />
-                    <input type="hidden" name="action_upscale_currency" value="{{ profile.currency }}" />
-                    <input type="hidden" name="action_upscale_previous_amount" value="{{ profile.amount }}" />
-                    <input type="hidden" name="action_upscale_mailing_clicked_amount" value="{{ args.clicked }}" />
-                </form>
-            </div>
-
-            <div id="confirm-amount-change">
-
-            {% for amount in args.amounts|split:',' %}
-                <div style="padding: 1em;">
-                <div
-                    data-wm-donate-widget
-                    class="donate-widget{% if amount == args.clicked %} selected{% endif %}"
-                    data-ak_locale="en"
-                    data-akid="{{ logged_in_user.token }}"
-                    data-mode="change"
-                    data-recurring_id="{{ args.profile }}"
-                    data-change_amount="{{ amount }}"
-                    data-selected_currency="{{ args.currency }}"
-                    ></div>
-                </div>
-            {% endfor %}
-
-            </div>
-
-            <script>
-                document.addEventListener('payment-update', (evt) => {
-                    const form = document.getElementById('actionkit-form');
-                    form.action_upscale_amount.value = evt.detail.amount;
-                    form.submit();
-                })
-            </script>
+        <div class="recurring-update-about-text">{% include_tmpl form.update_card_text %}</div>
 
 
         {% endif %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -55,7 +55,7 @@ TODO:
                 <div
                     class="donate-widget"
                     data-ak_locale="en"
-                    data-akid="{{ args.akid }}"
+                    data-akid="{{ logged_in_user.token }}"
                     data-mode="change"
                     data-recurring_id="{{ args.profile }}"
                     data-change_amount="{{ amount }}"
@@ -68,17 +68,43 @@ TODO:
         {% endif %}
 
 
-        {% if not active %}
-            <!-- p>Whoops! You don't have any active recurring donations to update.</!-->
-        {% else %}
-            {% for profile in active %}
-                {% include "./recurring_info.html" %}
-            {% endfor %}
-        {% endif %}
+        <div id="active-donations">
+        </div>
+
+
+        {% comment %}
+
+        OK, the code below  gets the current user's active recurring donations, but it has
+        a few problems before we can do anything interesting like "Hey Bob! You currently
+        have a monthly/weekly donation for X that started on Y and you've given Z total!"
+
+        - a field to tell if the donation is weekly / monthly needs to be added in the report
+        - translations need to be added
+
+        So totally doable if we need it.
+
+        <script>
+        const donations = [{% report "recurring_donations_for_user" with logged_in_user.id as user_id "active" as status args.t as cache_key %}];
+        const subscriptions = donations[0];
+        let info = '<ul>';
+        const fields = subscriptions[0];
+        for (var i=1; i<subscriptions.length; i++) {
+            const d = {};
+            for (var x=0;x<fields.length;x++) {
+                d[fields[x]] = subscriptions[i][x]
+            }
+            info += `<b>${d.recurring_id}</b>`;
+        }
+        info += '</ul>';
+        document.getElementById('active-donations').innerHTML = info;
+        </script> {% endcomment %}
+
+
 
         {% comment %}
             This is an example of how to show inactive profiles.
             {% if inactive %}
+
 
                 <label class="ak-label-above">Your old, no longer active recurring donations</label>
                 <ul>

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -57,24 +57,28 @@ For now this page is entirely dependent on the query string ! If we ever need to
             amount, currency, status, account, start_date
 
         {% endcomment %}
-        {% store as profiles %}
+        {% store as profile_details %}
         {% report "recurring_profile" with args.profile as recurring_id logged_in_user.id as user_id %}
         {% endstore %}
 
-        {% remember profiles.0 as profile %}
+        {% with profile_details|load_json as profile %}
 
         {% if action %}
+
             <h3>Update saved!</h3>
             <div>
                 {% include_tmpl form.thank_you_text %}
             </div>
-        {% else %}
+
+            {% else %}
 
             <div style="display: none;">
                 <form id="actionkit-form" name="act" action="/act/" method="POST">
-                    <input type="hidden" name="page" value="tracking-upscaled-donations" />
+                    <input type="hidden" name="page" value="tracking-upscaled-donations-{{ page.lang.iso_code }}" />
                     <input type="hidden" name="akid" value="{{ logged_in_user.token }}" />
                     <input type="hidden" name="action_upscale_page" value="{{ page.name }}" />
+                    <input type="hidden" name="action_profile" value="{{ profile.id }}" />
+                    <input type="hidden" name="action_recurring_id" value="{{ profile.recurring_id }}" />
                     <input type="hidden" name="action_upscale_amount" value="" />
                     <input type="hidden" name="action_upscale_currency" value="{{ profile.currency }}" />
                     <input type="hidden" name="action_upscale_previous_amount" value="{{ profile.amount }}" />
@@ -113,6 +117,7 @@ For now this page is entirely dependent on the query string ! If we ever need to
 
         {% endif %}
 
+        {% endwith %}
 
 
     </div>

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -14,7 +14,7 @@ There are a couple ways to update a recurring donation:
 {% endcomment %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.wemove.eu/donate-main.css" />
+<link rel="stylesheet" href="https://donate-ui.not-a2.eu/donate-main.css" />
 
 {% endblock %}
 
@@ -114,5 +114,5 @@ There are a couple ways to update a recurring donation:
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.wemove.eu/donate-main.js"></script>
+<script type="module" src="https://donate-ui.not-a2.eu/donate-main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/main.css" />
+<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/donate-main.css" />
 
 {% endblock %}
 
@@ -119,5 +119,5 @@ TODO:
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.not-a2.eu/assets/main.js"></script>
+<script type="module" src="https://donate-ui.not-a2.eu/assets/donate-main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -2,298 +2,11 @@
 {% load humanize %}
 
 {% block css_additions %}
-{% for profile in active %}
-{% if profile.payment_processor_information.use_vzero or profile.payment_processor_information.use_vgs %}
-{% once %}
-<style type="text/css">
-.hosted-field {
-    height: 2.375em;;
-    display: inline-block;
-    padding: 7px 7px;
-    border: 1px solid #ccc;
-    background-color: white;
-}
-</style>
-{% endonce %}
-{% endif %}
-{% if profile.payment_processor_information.use_vzero %}
-{% once %}
-<style type="text/css">
-.hosted-field.braintree-hosted-fields-invalid {
-    border-color: {{ templateset.custom_fields.color_error|default:"#d00" }};
-    background-color: #FFC8C8;
-}
-</style>
-{% endonce %}
-{% endif %}
-{% if profile.payment_processor_information.use_vgs %}
-  {% once %}
-  <style type="text/css">
-  .hosted-field iframe {width: 100%; height:100%; }
-  </style>
-  {% endonce %}
-{% endif %}
-{% endfor %}
+<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/main-a6ba8b10.css" />
+
 {% endblock %}
 
 {% block script_additions %}
-
-<script>
-    function ak_recurring_change_amount(profile_id) {
-        var profile_el = $('#change_profile_' + profile_id);
-        profile_el.find('.ak-show-amount').hide();
-        profile_el.find('.ak-change-amount').fadeIn();
-        profile_el.find('.ak-change-submit').fadeIn();
-        return false;
-    }
-
-    function ak_recurring_change_card(profile_id) {
-        var profile_el = $('#change_profile_' + profile_id);
-        profile_el.find('.ak-show-cc').hide();
-        profile_el.find('.ak-change-cc').not('.ak-business_name').fadeIn();
-        profile_el.find('.ak-change-address').fadeIn();
-        profile_el.find('.ak-change-submit').fadeIn();
-        profile_el.find(':input').prop('disabled', false);
-        return false;
-    }
-
-    function ak_recurring_change_address(profile_id) {
-        var profile_el = $('#change_profile_' + profile_id);
-        profile_el.find('.ak-show-address').hide();
-        profile_el.find('.ak-change-address').fadeIn();
-        profile_el.find('.ak-change-submit').fadeIn();
-        profile_el.find(':input').prop('disabled', false);
-        return false;
-    }
-
-    $(document).ready(function() {
-        var match = /profile_id=(\d+)/.exec(window.location.search);
-        if (match) {
-            var profile_id = match[1];
-            if (/error_card_num/.test(window.location.search) ||
-                /error_address1/.test(window.location.search) ||
-                /error_city/.test(window.location.search) ||
-                /error_profile_id/.test(window.location.search)) {
-                ak_recurring_change_card(profile_id);
-            } else if (/amount=/.test(window.location.search)) {
-                ak_recurring_change_amount(profile_id);
-            }
-        }
-    });
-</script>
-
-{% for profile in active %}
-
-{% if profile.payment_processor_information.use_accept %}
-{% once %}
-<script src="/resources/ak_authnet_accept.js"></script>
-{% authnet_js_libs %}
-<script>
-$(function() {
-    var form = $("#change_profile_{{ profile.id }}").get(0);
-    options = {
-            form: form,
-            submit: $("#change_profile_{{ profile.id }} .ak-change-submit button").get(0),
-    };
-    actionkit.authnet.initClient('{{ profile.payment_processor_information.login }}', '{{ profile.payment_processor_information.public_key }}', options);
-});
-</script>
-{% endonce %}
-{% endif %}
-{% if profile.payment_processor_information.use_vgs %}
-{% once %}
- <script src="https://js.verygoodvault.com/vgs-collect/2.8/vgs-collect.js"></script>
- <script src="/resources/ak_vgs.js"></script>
-{% endonce %}
-{% endif %}
-{% if profile.payment_processor_information.use_vzero %}
-{% once %}
-{% braintree_js_libs %}
-<script src="/resources/ak_braintree_vzero.js"></script>
-<script>
-function initVZeroForForm(form_id, clientToken, is_ach, use_3d_secure, nonce, bin) {
-    var form = document.querySelector(form_id),
-        options = {
-            form: form,
-            fields: {
-                number: {
-                    selector: form_id + ' .ak-card_num-hosted'
-                },
-                cvv: {
-                    selector: form_id + ' .ak-card_code-hosted'
-                },
-                expirationDate: {
-                    selector: form_id + ' .ak-exp_date-hosted',
-                    placeholder: 'MM / YYYY'
-                }
-            },
-            styles: {
-                'input': {
-                    'font-family': '{{ templateset.custom_fields.font_family|default:"sans-serif"|safe }}',
-                    'font-size': '{{ templateset.custom_fields.font_size|default:"16.5px" }}',
-                    'color': '#4b4b4b'
-                },
-                'input.invalid': {
-                    'color': '{{templateset.custom_fields.color_error|default:"#d00" }}',
-                    'background-color': '#FFC8C8'
-                },
-                'input.valid': {
-                    'color': 'green'
-                }
-            },
-            submit: form.querySelector("button[type=submit]"),
-            use_3d_secure: !!use_3d_secure,
-            nonce: nonce,
-            bin: bin,
-            isRecurringUpdate: true,
-            // allow empty submit so just amount can be changed
-            submitOnEmpty: function() { return true; }
-        },
-        toRemove = ["input[name=card_num]", "input[name=card_code]",
-                    "input[name=exp_date]"];
-
-    if (is_ach) {
-        options['fields'] = {};
-        options['ach'] = true;
-    } else {
-        toRemove.forEach(function(el) {
-            form.querySelector(el).remove();
-        });
-        Object.keys(options.fields).forEach(function(key) {
-            var field = options.fields[key];
-            document.querySelector(field.selector).classList.add('hosted-field');
-        });
-    }
-
-    actionkit.donations.initClient(clientToken, options);
-}
-</script>
-
-{% endonce %}
-{% endif %}
-{% if profile.payment_processor_information.processor == 'stripe' %}
-{% once %}
-<script src="https://js.stripe.com/v2/"></script>
-<script>
-$(function() {
-    $('[data-stripe-pub-key] [name=card_num]').attr('data-stripe', 'number');
-    $('[data-stripe-pub-key] [name=exp_date]').attr('data-stripe', 'exp');
-    $('[data-stripe-pub-key] [name=card_code]').attr('data-stripe', 'cvc');
-});
-window.actionkitBeforeSubmit = function() {
-    var $form = $(actionkit.form);
-    // user can have non-stripe and stripe recurrings--don't interfere with
-    // non-stripe forms
-    var stripePubKey = $form.attr('data-stripe-pub-key');
-    if ( stripePubKey ) {
-        Stripe.setPublishableKey(stripePubKey)
-    }
-    else {
-        return;
-    }
-    // user might just be changing amount
-    if ( !$form.find('[name=card_num]').is(':visible') )
-        return;
-
-    var $expField = $form.find('[name=exp_date]');
-    var exp = $expField.val();
-    // Stripe wants exp as 12/99 not 1299
-    exp = exp.replace(/[^0-9]/g, '').replace(/^([0-9][0-9])/, function(match) { return match + '/' });
-    $expField.val(exp);
-    try {
-        Stripe.card.createToken(actionkit.form, onStripeResponse);
-    } catch(e) {
-        // Stripe will throw (rather than return a failed response) for an
-        // out of range exp date month.
-        $expField.val(
-            $expField.val().replace('/', '')
-        );
-        alert('Sorry, we could not process your credit card information. Check your entries, such as your expiration date format, and try again.')
-        throw e;
-    }
-    return false;
-}
-function onStripeResponse(status, response) {
-    var $form = $(actionkit.form);
-    var $cardNumField = $form.find('[name=card_num]')
-    if ( response.error ) {
-        alert('We could not process your credit card information: ' + response.error.message);
-        $cardNumField.focus();
-        return;
-    }
-    $cardNumField.attr('disabled', true);
-    $cardNumField.after('<input type="hidden" name="card_num" value="token:' + response.id + '">')
-    // Stripe got exp_date in the format it wants, but set it back to the
-    // format ActionKit wants:
-    var $expField = $form.find('[name=exp_date]');
-    $expField.val(
-        $expField.val().replace('/', '')
-    );
-    actionkit.form.submit()
-}
-</script>
-{% endonce %}
-{% endif %}
-{% endfor %}
-
-<script>
-function valid_bank_account_number(value) {
-    return /^\d{4,17}$/.test(value);
-}
-
-function valid_bank_routing_number(value) {
-    value = value.replace(/\D/g,'');
-
-    if (value.length != 9) { return false; }
-
-    var checksum = 0;
-    for (var i = 0; i < value.length; i += 3) {
-        checksum += parseInt(value.charAt(i), 10) * 3
-                 +  parseInt(value.charAt(i + 1), 10) * 7
-                 +  parseInt(value.charAt(i + 2), 10);
-    }
-
-    if (checksum == 0 || checksum % 10 != 0) { return false; }
-
-    return true;
-}
-
-function validate_business_name(input) {
-    form = input.form;
-    if (input.value == 'business' && !form['business_name'].value) {
-        return "Business name is required for business accounts.";
-    }
-
-    return true;
-}
-
-function ach_validation(form) {
-    actionkit.forms.setForm(form);
-
-    // allow changing amount separately
-    if ($(form['bank_account']).is(':hidden')) { return true; }
-
-    // clear_errors will delete these inputs from other
-    // forms if we don't remove the error class from them here
-    $(':input.ak-error, label.ak-error').removeClass('ak-error');
-
-    // address is required for ACH changes, even for logged in users
-    var saved_state = actionkit.forms.alwaysRequireUserFields;
-    actionkit.forms.alwaysRequireUserFields = true;
-    var is_valid = actionkit.forms.validate();
-    actionkit.forms.alwaysRequireUserField = saved_state;
-
-    return is_valid;
-}
-
-/* This prevents the invisible inputs from being submitted. Needed
- because reflectCountryChange() messes with the disabled prop. */
-function disable_invisibles(form) {
-    $(form).find(':input:hidden[type!="hidden"]').prop('disabled', true);
-    return true;
-}
-</script>
-
 {% endblock %}
 
 {% block content %}
@@ -304,6 +17,13 @@ function disable_invisibles(form) {
     </div>
 </div>
 
+{% comment %}
+TODO:
+
+- active has nothing in it even for users that have active recurring donations
+- inactive has some
+
+{% endcomment %}
 <div class="ak-grid-row ak-grid-row-inverted">
     {% if page.custom_fields.featured_image %}
         <div class="ak-grid-col ak-grid-col-3-of-12">
@@ -313,23 +33,43 @@ function disable_invisibles(form) {
     <div class="ak-grid-col {% if page.custom_fields.featured_image %} ak-grid-col-9-of-12 {% else %}ak-grid-col-12-of-12 {% endif %}">
 
         <div>
-            <p>Logged in as <a href="/me/">{{ logged_in_user.name }}</a>. <a href="/logout/">Log out</a></p>
+            <p>Hello {{ logged_in_user.name }} ! If you're not {{ logged_in_user.name }}, please <a href="/logout/">click here.</a></p>
         </div>
+
         <div style="display:none">{% comment %}actionkit.js wants this, but we don't{% endcomment %}
             <p id="unknown_user"></p>
             <div id="known_user"><span id="known_user_name"></span></div>
         </div>
+
+        <p>{% include_tmpl form.update_card_text %}</p>
+
         {% if action %}
             <h3>Update saved!</h3>
             <div>
                 {% include_tmpl form.thank_you_text %}
             </div>
+        {% else %}
+
+            {% for amount in args.amounts|split:',' %}
+                <div style="padding: 1em;">
+                <div
+                    class="donate-widget"
+                    data-ak_locale="en"
+                    data-akid="{{ args.akid }}"
+                    data-mode="change"
+                    data-recurring_id="{{ args.profile }}"
+                    data-change_amount="{{ amount }}"
+                    data-selected_currency="{{ args.currency }}"
+                    ></div>
+                </div>
+            {% endfor %}
+
+
         {% endif %}
 
-        <p>{% include_tmpl form.update_card_text %}</p>
 
         {% if not active %}
-            <p>Whoops! You don't have any active recurring donations to update.</p>
+            <!-- p>Whoops! You don't have any active recurring donations to update.</!-->
         {% else %}
             {% for profile in active %}
                 {% include "./recurring_info.html" %}
@@ -343,14 +83,15 @@ function disable_invisibles(form) {
                 <label class="ak-label-above">Your old, no longer active recurring donations</label>
                 <ul>
                     {% for profile in inactive %}
-                    <li>{{ profile.status }} on {{ profile.updated_at }}. Started on {{ profile.start }}, {% with profile.payment_count as count %} {{ count }} {{ profile.get_period_display|lower }} payment{{ count|pluralize }}{% endwith %} were made for a total of {{ profile.payment_total_amt }}.</li>
+                    <li>{{ profile.id }} - {{ profile.status }} on {{ profile.updated_at }}. Started on {{ profile.start }}, {% with profile.payment_count as count %} {{ count }} {{ profile.get_period_display|lower }} payment{{ count|pluralize }}{% endwith %} were made for a total of {{ profile.payment_total_amt }}.</li>
                     {% endfor %}
                 </ul>
             {% endif %}
+
         {% endcomment %}
 
     </div>
 
 </div>
-
+<script type="module" src="https://donate-ui.not-a2.eu/assets/main-e45c39d4.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -11,12 +11,10 @@ There are a couple ways to update a recurring donation:
  - Change the amount (upscaling). DONE.
  - Change the payment method.     TODO.
 
-For now this page is entirely dependent on the query string ! If we ever need to pull in data about the current recurring donation(s), we'll need to use a report. I couldn't figure out why the built-in ActionKit template doesn't find any recurring donations. Maybe it ignored "Import Stub" payment accounts? I don't know.
-
 {% endcomment %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.not-a2.eu/donate-main.css" />
+<link rel="stylesheet" href="https://donate-ui.wemove.eu/donate-main.css" />
 
 {% endblock %}
 
@@ -50,13 +48,6 @@ For now this page is entirely dependent on the query string ! If we ever need to
 
         <p>{% include_tmpl form.update_card_text %}</p>
 
-        {% comment %} 
-          
-        This report returns these fields in this order:
-
-            amount, currency, status, account, start_date
-
-        {% endcomment %}
         {% store as profile_details %}
         {% report "recurring_profile" with args.profile as recurring_id logged_in_user.id as user_id %}
         {% endstore %}
@@ -123,5 +114,5 @@ For now this page is entirely dependent on the query string ! If we ever need to
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.not-a2.eu/donate-main.js"></script>
+<script type="module" src="https://donate-ui.wemove.eu/donate-main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -98,9 +98,7 @@ There are a couple ways to update a recurring donation:
                 document.addEventListener('payment-update', (evt) => {
                     const form = document.getElementById('actionkit-form');
                     console.debug(evt);
-                    // TODO: evt.amount is just a made-up placeholder, update to whatever the 
-                    //       widget actually sends.
-                    form.action_upscale_amount.value = evt.amount;
+                    form.action_upscale_amount.value = evt.detail.amount;
                     form.submit();
                 })
             </script>

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.not-a2.eu/assets/donate-main.css" />
+<link rel="stylesheet" href="https://donate-ui.not-a2.eu/donate-main.css" />
 
 {% endblock %}
 
@@ -119,5 +119,5 @@ TODO:
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.not-a2.eu/assets/donate-main.js"></script>
+<script type="module" src="https://donate-ui.not-a2.eu/donate-main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -14,7 +14,7 @@ There are a couple ways to update a recurring donation:
 {% endcomment %}
 
 {% block css_additions %}
-<link rel="stylesheet" href="https://donate-ui.not-a2.eu/donate-main.css" />
+<link rel="stylesheet" href="https://donate-ui.wemove.eu/donate-main.css" />
 
 {% endblock %}
 
@@ -114,5 +114,5 @@ There are a couple ways to update a recurring donation:
     </div>
 
 </div>
-<script type="module" src="https://donate-ui.not-a2.eu/donate-main.js"></script>
+<script type="module" src="https://donate-ui.wemove.eu/donate-main.js"></script>
 {% endblock %}

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -81,6 +81,7 @@ There are a couple ways to update a recurring donation:
             {% for amount in args.amounts|split:',' %}
                 <div style="padding: 1em;">
                 <div
+                    data-wm-donate-widget
                     class="donate-widget"
                     data-ak_locale="en"
                     data-akid="{{ logged_in_user.token }}"

--- a/WeMove/recurring_update.html
+++ b/WeMove/recurring_update.html
@@ -46,13 +46,14 @@ There are a couple ways to update a recurring donation:
             <div id="known_user"><span id="known_user_name"></span></div>
         </div>
 
-        <p>{% include_tmpl form.update_card_text %}</p>
 
         {% store as profile_details %}
         {% report "recurring_profile" with args.profile as recurring_id logged_in_user.id as user_id %}
         {% endstore %}
 
         {% with profile_details|load_json as profile %}
+
+        <div class="recurring-update-about-text">{% include_tmpl form.update_card_text %}</div>
 
         {% if action %}
 
@@ -61,7 +62,7 @@ There are a couple ways to update a recurring donation:
                 {% include_tmpl form.thank_you_text %}
             </div>
 
-            {% else %}
+        {% else %}
 
             <div style="display: none;">
                 <form id="actionkit-form" name="act" action="/act/" method="POST">
@@ -73,6 +74,7 @@ There are a couple ways to update a recurring donation:
                     <input type="hidden" name="action_upscale_amount" value="" />
                     <input type="hidden" name="action_upscale_currency" value="{{ profile.currency }}" />
                     <input type="hidden" name="action_upscale_previous_amount" value="{{ profile.amount }}" />
+                    <input type="hidden" name="action_upscale_mailing_clicked_amount" value="{{ args.clicked }}" />
                 </form>
             </div>
 
@@ -82,7 +84,7 @@ There are a couple ways to update a recurring donation:
                 <div style="padding: 1em;">
                 <div
                     data-wm-donate-widget
-                    class="donate-widget"
+                    class="donate-widget{% if amount == args.clicked %} selected{% endif %}"
                     data-ak_locale="en"
                     data-akid="{{ logged_in_user.token }}"
                     data-mode="change"
@@ -98,7 +100,6 @@ There are a couple ways to update a recurring donation:
             <script>
                 document.addEventListener('payment-update', (evt) => {
                     const form = document.getElementById('actionkit-form');
-                    console.debug(evt);
                     form.action_upscale_amount.value = evt.detail.amount;
                     form.submit();
                 })


### PR DESCRIPTION
Feature: An "upscale" page that asks users to confirm updating their recurring donation to a new amount. 

Changes:

- The login page now sends a magic link (using a confirmation email on a signup page) rather than asking for a password.
- The recurring update page shows buttons to change the amount (not change cards or payment methods)
- When a change in amount is confirmed, the form is submitted to a signup page which sends a confirmation email.

TODO:

- i18n; different confirmation emails, so different signup pages. we can use a query param for this too.
- pull details about the existing recurring donation into the page from a report (no need right now)
- show some kind of "working on it" message when they've clicked to confirm
