### PR TITLE
Redirect user to first step of daisy chain if not recognised

### DIFF
--- a/WeMove/component-call_page-tweet.html
+++ b/WeMove/component-call_page-tweet.html
@@ -16,6 +16,14 @@
 {% include "./user_form_wrapper.html" %}
 
 <script>
+  const handleUnrecognizedUser = () => {
+    const daisyChainAction = {{ page.custom_fields.daisy_chain_action|json }};
+    const recognizedUser = actionkit.context?.recognized_user;
+    if (!recognizedUser && daisyChainAction) {
+      window.location.replace(`/sign/${daisyChainAction}/`);
+    }
+  };
+
   const queryTargets = [{% report "call_page_target_information" with page.id as page_id %}];
   queryTargets.shift();
 
@@ -56,6 +64,10 @@
   }
 
   const prepareTweet = () => {
+    if (handleUnrecognizedUser()) {
+      return;
+    }
+
     pageTargets = actionkit.context.targets?.targets ? actionkit.context.targets.targets : [];
 
     const textArea = document.querySelector("[data-wm-tweet-message]");

--- a/WeMove/component-call_page-tweet.html
+++ b/WeMove/component-call_page-tweet.html
@@ -16,13 +16,6 @@
 {% include "./user_form_wrapper.html" %}
 
 <script>
-  const handleUnrecognizedUser = () => {
-    const daisyChainAction = {{ page.custom_fields.daisy_chain_action|json }};
-    const recognizedUser = actionkit.context?.recognized_user;
-    if (!recognizedUser && daisyChainAction) {
-      window.location.replace(`/sign/${daisyChainAction}/`);
-    }
-  };
 
   const queryTargets = [{% report "call_page_target_information" with page.id as page_id %}];
   queryTargets.shift();
@@ -64,7 +57,12 @@
   }
 
   const prepareTweet = () => {
-    if (handleUnrecognizedUser()) {
+    // Redirect unrecognised users to the first step of daisy chain
+    const daisyChainAction = {{ page.custom_fields.daisy_chain_action|json }}
+    const recognizedUser = actionkit.context?.recognized_user;
+    if (!recognizedUser && daisyChainAction) {
+      const urlParams = window.location.search || '';
+      window.location.replace(`/sign/${daisyChainAction}${urlParams}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

https://wemove-europe.monday.com/boards/1864533892

Previously, unrecognised users who submitted the tweet form were not being directed to the next step in the daisy chain. This happened because ActionKit changes unrecognised users to recognised after the tweet form submission, but doesn’t automatically advance them to the following page, and instead reloads the existing tweet page in a 'user recognised' state.

This update ensures unrecognised users are immediately redirected to the first step of the daisy chain (the signup page), where we can collect their details before they reach the tweet form.

The redirect logic was added at the start of the prepareTweet() function, which runs once the ActionKit context is fully loaded. This ensures we can safely check actionkit.context.recognized_user before proceeding. If the user is unrecognised and daisy_chain_action is defined, we redirect them to the corresponding /sign/ page and stop further script execution.

## Testing
https://action.wemove.eu/call/2025-10-15-aaron-onboarding-tweet-EN
correctly redirects to
https://action.wemove.eu/sign/2025-10-15-aaron-onboarding-petition-EN/

https://action.wemove.eu/call/2025-10-15-aaron-onboarding-tweet-EN?akid=.2174112.NP8w5k&action_id=12613728&consent=inline
does not redirect (user is recognised)